### PR TITLE
feat: pallet move incorporated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,6 +4421,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "node-template-runtime",
+ "pallet-move-rpc",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "sc-basic-authorship",
@@ -4468,6 +4469,8 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-grandpa",
+ "pallet-move",
+ "pallet-move-runtime-api",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",
@@ -4749,6 +4752,39 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-move"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "pallet-move-rpc"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "jsonrpsee",
+ "pallet-move-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-move-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Substrate Node Template
 
+*Notice:* node template from this git branch (`polkadot-1.0.0-pallet-move`) demands Move pallet to be placed in the same directory as the node template. Move pallet will be compiled with the node and user will be able to execute extrinsics and RPC using standard mechanisms.
+
 A fresh [Substrate](https://substrate.io/) node, ready for hacking :rocket:
 
 A standalone version of this template is available for each release of Polkadot in the [Substrate Developer Hub Parachain Template](https://github.com/substrate-developer-hub/substrate-parachain-template/) repository.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -61,6 +61,8 @@ frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/pari
 # Local Dependencies
 node-template-runtime = { version = "4.0.0-dev", path = "../runtime" }
 
+pallet-move-rpc = { version = "0.1.0", path = "../../pallet-move/rpc" }
+
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -37,21 +37,25 @@ where
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
+	C::Api: pallet_move_rpc::MoveRuntimeApi<Block, AccountId>,
 	P: TransactionPool + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
+	use pallet_move_rpc::{MovePallet, MoveApiServer};
 
 	let mut module = RpcModule::new(());
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
 	module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
-	module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed
 	// to call into the runtime.
 	// `module.merge(YourRpcTrait::into_rpc(YourRpcStruct::new(ReferenceToClient, ...)))?;`
+
+	module.merge(MovePallet::new(client.clone()).into_rpc())?;
 
 	Ok(module)
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -50,6 +50,9 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 # Local Dependencies
 pallet-template = { version = "4.0.0-dev", default-features = false, path = "../pallets/template" }
 
+pallet-move = { version = "0.1.0", default-features = false, path = "../../pallet-move" }
+pallet-move-runtime-api = { path = "../../pallet-move/rpc/runtime-api", default-features = false }
+
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v1.0.0" }
 
@@ -87,6 +90,8 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
+	"pallet-move/std",
+	"pallet-move-runtime-api/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -99,6 +104,7 @@ runtime-benchmarks = [
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-move/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-try-runtime/try-runtime",
@@ -112,4 +118,5 @@ try-runtime = [
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
+	"pallet-move/try-runtime",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -482,6 +482,34 @@ impl_runtime_apis! {
         fn weight_to_gas(weight: Weight) -> u64 {
             100									// Hardcoded for testing
         }
+
+		// Estimate gas for publish module.
+        fn estimate_gas_publish(account: AccountId, bytecode: Vec<u8>, gas_limit: u64) -> u64 {
+			100									// Hardcoded for testing
+        }
+
+        // Estimate gas for execute script.
+        fn estimate_gas_execute(account: AccountId, bytecode: Vec<u8>, gas_limit: u64) -> u64 {
+			100									// Hardcoded for testing
+        }
+
+        // Get module binary by it's address
+        fn get_module(module_id: Vec<u8>) -> Result<Option<Vec<u8>>, Vec<u8>> {
+            Ok(Some(module_id.clone()))
+        }
+
+        // Get module ABI by it's address
+        fn get_module_abi(module_id: Vec<u8>) -> Result<Option<Vec<u8>>, Vec<u8>> {
+            Ok(Some(module_id.clone()))
+        }
+
+        // Get resource
+        fn get_resource(
+            account: AccountId,
+            tag: Vec<u8>,
+        ) -> Result<Option<Vec<u8>>, Vec<u8>> {
+            Ok(Some(tag.clone()))
+        }
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -49,6 +49,9 @@ pub use sp_runtime::{Perbill, Permill};
 /// Import the template pallet.
 pub use pallet_template;
 
+/// Import the Move pallet.
+pub use pallet_move;
+
 /// An index to a block.
 pub type BlockNumber = u32;
 
@@ -274,6 +277,12 @@ impl pallet_template::Config for Runtime {
 	type WeightInfo = pallet_template::weights::SubstrateWeight<Runtime>;
 }
 
+/// Configure the pallet-move.
+impl pallet_move::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_move::weights::SubstrateWeight<Runtime>;
+}
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub struct Runtime {
@@ -286,6 +295,8 @@ construct_runtime!(
 		Sudo: pallet_sudo,
 		// Include the custom logic from the pallet-template in the runtime.
 		TemplateModule: pallet_template,
+		// Include the custom logic from the pallet-move in the runtime.
+		MoveModule: pallet_move,
 	}
 );
 
@@ -334,6 +345,7 @@ mod benches {
 		[pallet_timestamp, Timestamp]
 		[pallet_sudo, Sudo]
 		[pallet_template, TemplateModule]
+		[pallet_move, MoveModule]
 	);
 }
 
@@ -459,6 +471,17 @@ impl_runtime_apis! {
 		fn account_nonce(account: AccountId) -> Nonce {
 			System::account_nonce(account)
 		}
+	}
+
+	impl pallet_move_runtime_api::MoveApi<Block, AccountId> for Runtime {
+        fn gas_to_weight(gas_limit: u64) -> Weight {
+             Weight::from_parts(1_123_123, 0)	// Hardcoded for testing
+        }
+
+        // Convert Gas to Weight.
+        fn weight_to_gas(weight: Weight) -> u64 {
+            100									// Hardcoded for testing
+        }
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {


### PR DESCRIPTION
Pallet move for node-template.
Using the upstream polkadot-1.0.0 template from the main branch.

This makes `polkadot-1.0.0` and `polkadot-1.0.0-pallet-move` branches obsolete. They shouldn't be used anymore.