### PR TITLE
chore: add better estimate output to estimation RPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,6 +5178,7 @@ dependencies = [
  "jsonrpsee",
  "pallet-move-runtime-api",
  "parity-scale-codec",
+ "serde",
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
@@ -5189,7 +5190,9 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use pallet_grandpa::AuthorityId as GrandpaId;
+use pallet_move_runtime_api::types::MoveApiEstimation;
 use scale_info::prelude::{format, string::String};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -21,7 +22,7 @@ use sp_runtime::{
 		AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, One, Verify,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+	ApplyExtrinsicResult, DispatchError, MultiSignature,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -502,18 +503,32 @@ impl_runtime_apis! {
 		}
 
 		// Estimate gas for publishing a module.
-		fn estimate_gas_publish_module(account: AccountId, bytecode: Vec<u8>) -> u64 {
-			100
+		fn estimate_gas_publish_module(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, DispatchError> {
+			let vm_result = MoveModule::raw_publish_module(&account, bytecode, pallet_move::GasStrategy::DryRun)?;
+
+			Ok(MoveApiEstimation {
+				vm_status_code: vm_result.status_code.into(),
+				gas_used: vm_result.gas_used,
+			})
 		}
 
 		// Estimate gas for publishing a bundle.
-		fn estimate_gas_publish_bundle(account: AccountId, bytecode: Vec<u8>) -> u64 {
-			100
+		fn estimate_gas_publish_bundle(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, DispatchError> {
+			let vm_result = MoveModule::raw_publish_bundle(&account, bytecode, pallet_move::GasStrategy::DryRun)?;
+
+			Ok(MoveApiEstimation {
+				vm_status_code: vm_result.status_code.into(),
+				gas_used: vm_result.gas_used,
+			})
 		}
 
 		// Estimate gas for execute script.
-		fn estimate_gas_execute(account: AccountId, bytecode: Vec<u8>) -> u64 {
-			100
+		fn estimate_gas_execute(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, DispatchError> {
+			// TODO: implement raw_execute
+			Ok(MoveApiEstimation {
+				vm_status_code: 0,
+				gas_used: 0,
+			})
 		}
 
 		// Get module binary by it's Substrate address & name.


### PR DESCRIPTION
The user now gets two pieces of information:
- vm execution status
- gas used


It can be tested with:
`curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method":"mvm_estimateGasPublishBundle","params": ["12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU", [3,4]]}' http://localhost:9944/`