### PR TITLE
chore: move module genesis configuration

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -113,5 +113,8 @@ fn testnet_genesis(
 			// Assign network admin rights.
 			"key": Some(root_key),
 		},
+		"moveModule": {
+			"changeDefaultStdlibBundleTo": Option::<Vec<u8>>::None,
+		}
 	})
 }


### PR DESCRIPTION
The only option right now is to override the stdlib bundle.