### PR TITLE
dep: switch to rust stable 1.75.0 (ahash simd issue)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "1.75.0"
 components = [
 	"cargo",
 	"clippy",


### PR DESCRIPTION
After a dependency issue with feature `simd` in a couple of crates like `ahash`, we switch to Rust stable 1.75.0.
The connected crates `pallet-move`, `smove` and `substrate-move` used stable anyway.