### PR TITLE
feat: change pallet move dependencies to remote

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -61,8 +61,10 @@ substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk
 # These dependencies are used for runtime benchmarking
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "v1.12.0-rc3" }
 
+# Move Pallet
+pallet-move-rpc = { git = "https://github.com/eigerco/pallet-move" }
+
 # Local Dependencies
-pallet-move-rpc = { path = "../../pallet-move/rpc" }
 solochain-template-runtime = { path = "../runtime" }
 
 [build-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -72,8 +72,10 @@ pallet-transaction-payment-rpc-runtime-api = {  git = "https://github.com/parity
 frame-benchmarking = {  git = "https://github.com/paritytech/polkadot-sdk.git", tag = "v1.12.0-rc3", default-features = false, optional = true }
 frame-system-benchmarking = {  git = "https://github.com/paritytech/polkadot-sdk.git", tag = "v1.12.0-rc3", default-features = false, optional = true }
 
+# Move Pallet
+pallet-move = { git = "https://github.com/eigerco/pallet-move", default-features = false }
+
 # Local pallet dependencies.
-pallet-move = { path = "../../pallet-move/pallet", default-features = false }
 pallet-template = { path = "../pallets/template", default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
I’ve updated the template to use pallet-move dependencies from a remote Git repository instead of local references, making it easier for others to collaborate and reproduce the project. 
Additionally, I’ve updated the documentation and tutorial to reflect the correct steps for running the node template . [https://github.com/eigerco/pallet-move/pull/202](docs)